### PR TITLE
Feat: add copy button

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -156,22 +156,30 @@ or shell prompt.
 
 **macOS:** Open a terminal, paste the command shown below and press enter.
 
-```bash
-(touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.sh > tmp.sh && bash tmp.sh --prerelease --path --onefile) ; rm tmp.sh
-```
+.. code-block:: bash
+
+    (touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.sh > tmp.sh && bash tmp.sh --prerelease --path --onefile) ; rm tmp.sh
 
 **Linux:** Open a shell prompt, paste the command shown below and press enter.
 
-```bash
-(touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.sh > tmp.sh && bash tmp.sh --prerelease --path --onefile) ; rm tmp.sh
-```
+.. code-block:: bash
+
+    (touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.sh > tmp.sh && bash tmp.sh --prerelease --path --onefile) ; rm tmp.sh
+
+Note that if you're installing on CSF3 or CSF4 using this method, the proxy
+module should be loaded first. To do this, paste the command shown below
+into a the shell prompt and press enter.
+
+.. code-block:: bash
+
+    module load tools/env/proxy2
 
 **Windows:** Open a Powershell terminal, paste the command shown below and 
 press enter.
 
-```bash
-& $([scriptblock]::Create((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.ps1'))) -PreRelease -OneFile
-```
+.. code-block:: bash
+
+    & $([scriptblock]::Create((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-matflow.ps1'))) -PreRelease -OneFile
 
 Download binaries (v{release})
 ===============================

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,7 +149,7 @@ MatFlow CLI
 *******************************
 
 Install script (v{release})
-===========================t
+============================
 
 MatFlow CLI can be installed on macOS, Linux or Windows through a terminal
 or shell prompt.


### PR DESCRIPTION
Add copy button to install page to allow easy copying of shell commands to install matflow.

Closes #40 