### PR TITLE
docs: Change default install to folder

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -37,7 +37,7 @@
 
             .. code-block:: bash
 
-                (touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-{{ app_package_name }}.sh > tmp.sh && bash tmp.sh --prerelease --path --onefile) ; rm tmp.sh
+                (touch tmp.sh && curl -fsSL https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-{{ app_package_name }}.sh > tmp.sh && bash tmp.sh --prerelease --path) ; rm tmp.sh
 
         .. tab-item:: Windows
 
@@ -45,20 +45,24 @@
 
             .. code-block:: powershell
 
-                & $([scriptblock]::Create((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-{{ app_package_name }}.ps1'))) -PreRelease -OneFile
+                & $([scriptblock]::Create((New-Object Net.WebClient).DownloadString('https://raw.githubusercontent.com/hpcflow/install-scripts/main/src/install-{{ app_package_name }}.ps1'))) -PreRelease
 
     .. admonition:: What does this script do?
         :class: note dropdown
         
         The above command downloads a script from the {{ app_name }} GitHub repository and runs it. The script does the following:
 
-        #. It downloads the latest prerelease version of {{ app_name }} packaged up into a single executable.
-        #. The file is placed in an accessible location. The location depends on the operating system. In Linux it is ``/.local/share/matflow``. In macOS it is ``~/Library/Application Support/matflow``. In Windows it is ``Username\AppData\Local\matflow``.
-        #. A symbolic link (Linux/macOS) or an alias pointing to the file is created. This allows {{ app_name }} to be run by entering a simple command.
-        #. A command is added to ``.bashrc``/``.zshrc`` (linux/macOS) or the Powershell profile (Windows) that allows {{ app_name }} to be run from any folder.
+        #. It downloads the latest prerelease version of {{ app_name }} zip archived in a single folder.
+        #. The archive is extracted and the folder placed in an accessible location. The location depends on the 
+            operating system. In Linux it is ``/.local/share/matflow``. In macOS it is 
+            ``~/Library/Application Support/matflow``. In Windows it is ``Username\AppData\Local\matflow``.
+        #. A symbolic link (Linux/macOS) or an alias pointing to the file is created. This allows {{ app_name }} to be 
+            run by entering a simple command.
+        #. A command is added to ``.bashrc``/``.zshrc`` (linux/macOS) or the Powershell profile (Windows) that allows 
+            {{ app_name }} to be run from any folder.
 
-        If the script detects that the version of {{ app_name }} it is trying to install is already there, it will stop running
-        and exit.
+        If the script detects that the version of {{ app_name }} it is trying to install is already there, it will stop 
+        running and exit.
 
     .. hint::
       


### PR DESCRIPTION
Changes default install script to install the "one folder" version. Update the "What does this script do?" section to reflect changes. Closes #37.