### PR TITLE
Docs: fix bolded text

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -53,13 +53,9 @@
         The above command downloads a script from the {{ app_name }} GitHub repository and runs it. The script does the following:
 
         #. It downloads the latest prerelease version of {{ app_name }} zip archived in a single folder.
-        #. The archive is extracted and the folder placed in an accessible location. The location depends on the 
-            operating system. In Linux it is ``/.local/share/matflow``. In macOS it is 
-            ``~/Library/Application Support/matflow``. In Windows it is ``Username\AppData\Local\matflow``.
-        #. A symbolic link (Linux/macOS) or an alias pointing to the file is created. This allows {{ app_name }} to be 
-            run by entering a simple command.
-        #. A command is added to ``.bashrc``/``.zshrc`` (linux/macOS) or the Powershell profile (Windows) that allows 
-            {{ app_name }} to be run from any folder.
+        #. The archive is extracted and the folder placed in an accessible location. The location depends on the operating system. In Linux it is ``/.local/share/matflow``. In macOS it is ``~/Library/Application Support/matflow``. In Windows it is ``Username\AppData\Local\matflow``.
+        #. A symbolic link (Linux/macOS) or an alias pointing to the file is created. This allows {{ app_name }} to be run by entering a simple command.
+        #. A command is added to ``.bashrc``/``.zshrc`` (linux/macOS) or the Powershell profile (Windows) that allows {{ app_name }} to be run from any folder.
 
         If the script detects that the version of {{ app_name }} it is trying to install is already there, it will stop 
         running and exit.


### PR DESCRIPTION
Removed linebreaks from admonition section. This should fix inconsistent bolded text in compiled documentation.