### PR TITLE
Shared make vers switcher

### DIFF
--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -557,6 +557,7 @@ jobs:
 
       - name: Update doc version switcher
         run: |
+          curl https://raw.githubusercontent.com/{{ org }}/{{ repo }}/${{ github.head_ref }}/docs/make_vers_switcher.py --output docs/make_vers_switcher.py
           python docs/make_vers_switcher.py
 
       - name: Push changes


### PR DESCRIPTION
syncs with python_release_workflow (PR [#47](https://github.com/hpcflow/python-release-workflow/pull/47))

gets make_vers_switcher.py from github.head_ref using curl