### PR TITLE
fix: add a download-artifact@v3 step in release-github-PyPI to grab C…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,7 +474,10 @@ jobs:
       - run: mkdir release-artifacts
 
       - uses: actions/download-artifact@v4
-        id: download_executables
+        with:
+          path: release-artifacts
+
+      - uses: actions/download-artifact@v3 # for CentOS (docker) build-exes
         with:
           path: release-artifacts
 

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -474,7 +474,10 @@ jobs:
       - run: mkdir release-artifacts
 
       - uses: actions/download-artifact@v4
-        id: download_executables
+        with:
+          path: release-artifacts
+
+      - uses: actions/download-artifact@v3 # for CentOS (docker) build-exes
         with:
           path: release-artifacts
 


### PR DESCRIPTION
…entOS (docker) built executable which cannot use upload-artifact@v4