### PR TITLE
Remove Python 3.8 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -377,7 +377,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
+          - "3.9"
           - "3.12"
         os:
           - ubuntu-latest

--- a/.github/workflows/release.yml.in
+++ b/.github/workflows/release.yml.in
@@ -377,7 +377,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
+          - "3.9"
           - "3.12"
         os:
           - ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -181,7 +180,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -270,7 +268,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -373,7 +370,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -476,7 +472,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/test.yml.in
+++ b/.github/workflows/test.yml.in
@@ -92,7 +92,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -181,7 +180,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -270,7 +268,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -373,7 +370,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"
@@ -476,7 +472,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/matflow/data/demo_data/__init__.py
+++ b/matflow/data/demo_data/__init__.py
@@ -1,1 +1,1 @@
-# required for `demo_data` to be accessible as a package resource in Python 3.8/3.9
+# required for `demo_data` to be accessible as a package resource in Python 3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 exclude = ["matflow/data/demo_data"]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.13"
+python = ">=3.9,<3.13"
 pytest = {version = "^7.2.0", optional = true}
 matplotlib = "^3.7"
 hpcflow-new2 = "^0.2.0a178"


### PR DESCRIPTION
As with hpcflow/hpcflow-new#702, this removes Python 3.8 support (mainly from CI) as that reaches the end of security support this month.