### PR TITLE
299 test demo workflow simulate yield surface 2d

### DIFF
--- a/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
@@ -1,4 +1,4 @@
-function exitcode = plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
+function plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
     allOpts = jsondecode(fileread(inputs_JSON_path));
     crystalSym = allOpts.crystal_symmetry;
@@ -56,5 +56,4 @@ function exitcode = plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path
 
     close all;
 
-    exitcode = 1;
 end

--- a/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
@@ -4,7 +4,6 @@ function exitcode = plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path
     crystalSym = allOpts.crystal_symmetry;
     
     useContours = allOpts.use_contours;
-    plotIPFKey = allOpts.plot_IPF_key;
     IPFRefDirs = allOpts.IPF_reference_directions;
     
     % as defined in MatFlow
@@ -42,18 +41,15 @@ function exitcode = plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path
         quat_data = circshift(quat_data, 1, 2);
     end
     
-    if plotIPFKey
-        ipfKey = ipfColorKey(crystalSym);
-        plot(ipfKey);
-        saveFigure('IPF_key.png');
-    end
-    
     orientations = orientation(quat_data, crystalSym);
     
     if useContours
         plotIPDF(orientations,refDirs,'contourf');
     else
         plotIPDF(orientations,refDirs);
+        ipfKey = ipfColorKey(crystalSym);
+        plot(ipfKey);
+        saveFigure('IPF_key.png');
     end
     
     saveFigure('inverse_pole_figure.png');

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -52,6 +52,7 @@ function exitcode = plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     if useContours
         plotPDF(orientations, millerDirs, 'contourf');
         mtexColorbar;
+        plot_IPFKey = false;
     else
         ipfKey = ipfColorKey(crystalSym);
         ipfKey.inversePoleFigureDirection = vector3d.(upper(IPFRefDir));

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -1,4 +1,4 @@
-function exitcode = plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
+function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
     allOpts = jsondecode(fileread(inputs_JSON_path));
     crystalSym = allOpts.crystal_symmetry;    
@@ -131,5 +131,4 @@ function exitcode = plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
     close all;
 
-    exitcode = 1;
 end

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -3,7 +3,6 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     allOpts = jsondecode(fileread(inputs_JSON_path));
     crystalSym = allOpts.crystal_symmetry;    
     useContours = allOpts.use_contours;
-    plot_IPFKey = allOpts.plot_IPF_key;
     poleFigureDirections = allOpts.pole_figure_directions;
     IPFRefDir = allOpts.IPF_reference_direction;
 
@@ -52,7 +51,6 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     if useContours
         plotPDF(orientations, millerDirs, 'contourf');
         mtexColorbar;
-        plot_IPFKey = false;
     else
         ipfKey = ipfColorKey(crystalSym);
         ipfKey.inversePoleFigureDirection = vector3d.(upper(IPFRefDir));
@@ -62,6 +60,9 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
             millerDirs, ...
             'property', oriColors ...
         );
+        newMtexFigure('layout', [1, 1], 'visible', 'off');
+        plot(ipfKey);
+        saveFigure('IPF_key.png');
     end
 
     if ~isempty(allOpts.colourbar_limits)
@@ -122,12 +123,6 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     end
     
     saveFigure('pole_figure.png');
-
-    if plot_IPFKey
-        newMtexFigure('layout', [1, 1], 'visible', 'off');
-        plot(ipfKey);
-        saveFigure('IPF_key.png');
-    end
 
     close all;
 

--- a/matflow/data/template_components/command_files.yaml
+++ b/matflow/data/template_components/command_files.yaml
@@ -51,7 +51,8 @@
 
 - label: mtex_IPF_key
   name:
-    name: IPF_key.png
+    name: IPF_key\.png
+    is_regex: true
   doc: Key image for MTEX inverse pole figures.
 
 - label: dream_3D_pipeline

--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -435,15 +435,12 @@
     - parameter: crystal_symmetry
     - parameter: pole_figure_directions
     - parameter: use_contours
-      default_value: true
     - parameter: IPF_reference_direction
       default_value: z
     - parameter: colourbar_limits
       default_value: null
     - parameter: use_one_colourbar
       default_value: False
-    - parameter: plot_IPF_key
-      default_value: true
     - parameter: compile
       default_value: false
   actions:
@@ -500,9 +497,6 @@
     - parameter: IPF_reference_directions
       default_value: ["z"]
     - parameter: use_contours
-      default_value: true
-    - parameter: plot_IPF_key
-      default_value: true
     - parameter: compile
       default_value: false
   actions:
@@ -562,9 +556,6 @@
     - parameter: IPF_reference_directions
       default_value: ["z"]
     - parameter: use_contours
-      default_value: true
-    - parameter: plot_IPF_key
-      default_value: true
     - parameter: compile
       default_value: false
   actions:

--- a/matflow/data/workflows/cubic_textures.yaml
+++ b/matflow/data/workflows/cubic_textures.yaml
@@ -30,4 +30,5 @@ tasks:
       crystal_symmetry: cubic # so we only see one orientaion on the pole figure
       pole_figure_directions:
         - [1, 1, 1]
+      use_contours: true
       compile: false

--- a/matflow/data/workflows/simulate_yield_surface_2D.yaml
+++ b/matflow/data/workflows/simulate_yield_surface_2D.yaml
@@ -34,6 +34,7 @@ tasks:
       crystal_symmetry: cubic
       pole_figure_directions:
         - [1, 1, 1]
+      use_contours: true
       compile: false
 
   - schema: generate_volume_element_from_voronoi

--- a/matflow/data/workflows/simulate_yield_surface_2D_brass.yaml
+++ b/matflow/data/workflows/simulate_yield_surface_2D_brass.yaml
@@ -22,6 +22,7 @@ tasks:
       crystal_symmetry: cubic # so we only see one orientaion on the pole figure
       pole_figure_directions:
         - [1, 1, 1]
+      use_contours: true
       compile: false
 
   - schema: generate_microstructure_seeds_from_random


### PR DESCRIPTION
Fix #299 

However, I have a question about the default values of `use_contours` and `plot_IPF_key` in the task schema. If neither are specified in the task, then they take their default values (both `true`) and so we have the need for the changed logic in this PR such that the IPF_key is changed to `false` and the ipf_key diagram is not plotted. This doesn't really make sense as a default option if they're not both allowed to be `true`. 

As a minimum suggestion, I propose that the demo workflows specify a value for `use_contours`. The `sample_texture*` and `sample_orientations*` demo workflows already have a value set for`use_contours` whereas the `cubic_textures` and `simulate_yield_surface*` workflows do not.

One option for fixing the conflicting default values could be to always plot the ipf_key figure if not using contours, then we could do away with that input and remove the default value from `use_contours`, or have both keys as mandatory inputs. Perhaps there's a neater solution?

Perhaps I need to split this out into a separate issue?