### PR TITLE
fix: allow failure on macos for a test that gets rate-limited by github

### DIFF
--- a/matflow/tests/param_classes/test_load.py
+++ b/matflow/tests/param_classes/test_load.py
@@ -1,5 +1,7 @@
+import sys
 from pathlib import Path
 
+import requests
 import numpy as np
 
 import matflow as mf
@@ -25,6 +27,14 @@ def test_load_case_yaml_init(null_config, tmp_path: Path, load_case_1: LoadCase)
     assert load_case == load_case_1
 
 
+@pytest.mark.xfail(
+    condition=sys.platform == "darwin",
+    raises=requests.exceptions.HTTPError,
+    reason=(
+        "GHA MacOS runners use the same IP address, so we get rate limited when "
+        "retrieving demo data from GitHub."
+    ),
+)
 def test_load_case_from_npz_file():
     npz_file_path = mf.get_demo_data_file_path("load_cases.npz")
     file_dat = np.load(npz_file_path)

--- a/matflow/tests/param_classes/test_load.py
+++ b/matflow/tests/param_classes/test_load.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 import requests
 import numpy as np
 


### PR DESCRIPTION
Tests that use demo data files need to be "expected to fail" on MacOS due to GitHub rate limiting.