### PR TITLE
Fix plot pole figures

### DIFF
--- a/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
@@ -45,15 +45,15 @@ function plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     
     if useContours
         plotIPDF(orientations,refDirs,'contourf');
+        saveFigure('inverse_pole_figure.png');
     else
         plotIPDF(orientations,refDirs);
+        saveFigure('inverse_pole_figure.png');
+
         ipfKey = ipfColorKey(crystalSym);
         plot(ipfKey);
         saveFigure('IPF_key.png');
     end
-    
-    saveFigure('inverse_pole_figure.png');
 
     close all;
-
 end

--- a/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
@@ -8,11 +8,9 @@ function plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     
     % as defined in MatFlow
     latticeDirs = {'a', 'b', 'c', 'a*', 'b*', 'c*'};
-    reprTypes = {'quaternion', 'euler'};
     reprQuatOrders = {'scalar-vector', 'vector-scalar'};
     
     align = h5readatt(inputs_HDF5_path, '/orientations', 'unit_cell_alignment');
-    reprTypeInt = h5readatt(inputs_HDF5_path, '/orientations', 'representation_type');
     reprQuatOrderInt = h5readatt(inputs_HDF5_path, '/orientations', 'representation_quat_order');
     
     alignment = { ...
@@ -21,7 +19,6 @@ function plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
                      sprintf('Z||%s', latticeDirs{align(3) + 1}) ...
                  };
     crystalSym = crystalSymmetry(crystalSym, alignment{:});
-    oriType = reprTypes{reprTypeInt + 1};
     oriQuatOrder = reprQuatOrders{reprQuatOrderInt + 1};
     
     refDirs = vector3d.(upper(IPFRefDirs{1}));

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -21,11 +21,9 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     crystalSym = crystalSymmetry(crystalSym, alignment{:});
     oriQuatOrder = reprQuatOrders{reprQuatOrderInt + 1};
 
-    millerDirs = Miller(num2cell(poleFigureDirections(1, :)), crystalSym);
-
-    for i = 2:size(poleFigureDirections, 1)
-        newMillerDir = Miller(num2cell(poleFigureDirections(i, :)), crystalSym);
-        millerDirs = [millerDirs, newMillerDir];
+    millerDirs = cell(size(poleFigureDirections, 1));
+    for i = 1:size(poleFigureDirections, 1)
+        millerDirs{i} = Miller(num2cell(poleFigureDirections(i, :)), crystalSym);
     end
 
     data = h5read(inputs_HDF5_path, '/orientations/data');

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -60,9 +60,6 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
             millerDirs, ...
             'property', oriColors ...
         );
-        newMtexFigure('layout', [1, 1], 'visible', 'off');
-        plot(ipfKey);
-        saveFigure('IPF_key.png');
     end
 
     if ~isempty(allOpts.colourbar_limits)
@@ -123,6 +120,12 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
     end
     
     saveFigure('pole_figure.png');
+
+    if ~useContours
+        newMtexFigure('layout', [1, 1], 'visible', 'off');
+        plot(ipfKey);
+        saveFigure('IPF_key.png');
+    end
 
     close all;
 

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -8,11 +8,9 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
     % as defined in MatFlow
     latticeDirs = {'a', 'b', 'c', 'a*', 'b*', 'c*'};
-    reprTypes = {'quaternion', 'euler'};
     reprQuatOrders = {'scalar-vector', 'vector-scalar'};
 
     align = h5readatt(inputs_HDF5_path, '/orientations', 'unit_cell_alignment');
-    reprTypeInt = h5readatt(inputs_HDF5_path, '/orientations', 'representation_type');
     reprQuatOrderInt = h5readatt(inputs_HDF5_path, '/orientations', 'representation_quat_order');
 
     alignment = { ...
@@ -21,7 +19,6 @@ function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
                      sprintf('Z||%s', latticeDirs{align(3) + 1}) ...
                  };
     crystalSym = crystalSymmetry(crystalSym, alignment{:});
-    oriType = reprTypes{reprTypeInt + 1};
     oriQuatOrder = reprQuatOrders{reprQuatOrderInt + 1};
 
     millerDirs = Miller(num2cell(poleFigureDirections(1, :)), crystalSym);


### PR DESCRIPTION
Fix #409.

I also fixed some MATLAB warnings, but would really need an example to test in order to also preallocate for `refDirs` in `plot_inverse_pole_figures`. 

There are no matflow errors, but could you please check that the outputs are still the same after my changes?