### PR TITLE
Set MATLAB's RNG seed in MTEX scripts [skip release]

### DIFF
--- a/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_inverse_pole_figures.m
@@ -1,5 +1,7 @@
 function plot_inverse_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     allOpts = jsondecode(fileread(inputs_JSON_path));
     crystalSym = allOpts.crystal_symmetry;
     

--- a/matflow/data/scripts/mtex/plot_pole_figures.m
+++ b/matflow/data/scripts/mtex/plot_pole_figures.m
@@ -1,5 +1,7 @@
 function plot_pole_figures(inputs_HDF5_path, inputs_JSON_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     allOpts = jsondecode(fileread(inputs_JSON_path));
     crystalSym = allOpts.crystal_symmetry;    
     useContours = allOpts.use_contours;

--- a/matflow/data/scripts/mtex/sample_orientations_CRC.m
+++ b/matflow/data/scripts/mtex/sample_orientations_CRC.m
@@ -1,5 +1,7 @@
 function sample_orientations_CRC(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     CRCFilePath = all_args.CRC_file_path;

--- a/matflow/data/scripts/mtex/sample_orientations_CTF.m
+++ b/matflow/data/scripts/mtex/sample_orientations_CTF.m
@@ -1,5 +1,7 @@
 function sample_orientations_CTF(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     CTFFilePath = all_args.CTF_file_path;

--- a/matflow/data/scripts/mtex/sample_texture_CRC.m
+++ b/matflow/data/scripts/mtex/sample_texture_CRC.m
@@ -1,5 +1,7 @@
 function sample_texture_CRC(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     CRCFilePath = all_args.CRC_file_path;

--- a/matflow/data/scripts/mtex/sample_texture_CTF.m
+++ b/matflow/data/scripts/mtex/sample_texture_CTF.m
@@ -1,5 +1,7 @@
 function sample_texture_CTF(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     CTFFilePath = all_args.CTF_file_path;

--- a/matflow/data/scripts/mtex/sample_texture_ODF_mat.m
+++ b/matflow/data/scripts/mtex/sample_texture_ODF_mat.m
@@ -1,5 +1,7 @@
 function sample_texture_ODF_mat(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     ODFMatFilePath = all_args.ODF_mat_file_path;

--- a/matflow/data/scripts/mtex/sample_texture_model_ODF.m
+++ b/matflow/data/scripts/mtex/sample_texture_model_ODF.m
@@ -1,5 +1,7 @@
 function sample_texture_model_ODF(inputs_JSON_path, outputs_HDF5_path)
 
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     numOrientations = all_args.num_orientations;

--- a/matflow/data/scripts/mtex/sample_texture_random.m
+++ b/matflow/data/scripts/mtex/sample_texture_random.m
@@ -1,4 +1,7 @@
 function sample_texture_random(inputs_JSON_path, outputs_HDF5_path)
+
+    rng(str2double(getenv('MATFLOW_RUN_RANDOM_SEED')));
+    
     all_args = jsondecode(fileread(inputs_JSON_path));
 
     crystal_symmetry = all_args.crystal_symmetry;


### PR DESCRIPTION
This requires https://github.com/hpcflow/hpcflow/pull/959

This will allow, for example, sampling _distinct_ orientations from an ODF when using element `repeats`.