### PR TITLE
Set default execution mode to script for MTEX tasks

### DIFF
--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -206,7 +206,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script
       propagation_mode: explicit
     - parameter: CTF_file_path
     - parameter: specimen_symmetry
@@ -279,7 +279,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | script | compile
       propagation_mode: explicit
     - parameter: CRC_file_path
     - parameter: specimen_symmetry
@@ -352,7 +352,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
     - parameter: ODF_mat_file_path
     - parameter: num_orientations
@@ -423,7 +423,7 @@
     - parameter: specimen_symmetry
     - parameter: ODF_components
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
   outputs:
     - parameter: orientations
@@ -498,7 +498,7 @@
     - parameter: use_one_colourbar
       default_value: False
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
   actions:
     - requires_dir: true
@@ -571,7 +571,7 @@
       default_value: ["z"]
     - parameter: use_contours
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
   actions:
     - requires_dir: true
@@ -1512,7 +1512,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
     - parameter: CTF_file_path
     - parameter: specimen_symmetry
@@ -1585,7 +1585,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
     - parameter: CRC_file_path
     - parameter: specimen_symmetry
@@ -1658,7 +1658,7 @@
   implementation: mtex
   inputs:
     - parameter: execution_mode
-      default_value: precompiled # script | compile
+      default_value: script # precompiled | compile
       propagation_mode: explicit
     - parameter: specimen_symmetry
     - parameter: num_orientations


### PR DESCRIPTION
The precompiled MATLAB environment setup isn't documented, and isn't working reliably yet (see #517), so setting the default execution mode back to `script`.