### PR TITLE
Fix adaptive conditional sampling variant of the toy model subset simulation workflow

### DIFF
--- a/matflow/data/scripts/uq/collate_results.py
+++ b/matflow/data/scripts/uq/collate_results.py
@@ -51,9 +51,12 @@ def collate_results(g, x, p_0, all_g, all_x, all_accept, level_cov):
     if all_g:
         # from multiple Markov chains:
         g_unsrt = np.concatenate([i[:] for i in all_g])
-        accept = np.vstack([i[:] for i in all_accept])
+        all_all_accept = []
+        for iter_dat in all_accept.values():
+            if iter_dat["value"]:
+                all_all_accept.append(np.vstack([i[:] for i in iter_dat["value"]]))
+        accept_rate = np.mean(all_all_accept, axis=(1, 2))
         x = np.vstack([i[:] for i in all_x])
-        accept_rate = np.mean(accept)
     else:
         # from initial direct Monte Carlo samples:
         g_unsrt = np.array(g)

--- a/matflow/data/scripts/uq/generate_next_state.py
+++ b/matflow/data/scripts/uq/generate_next_state.py
@@ -86,4 +86,6 @@ def generate_next_state(x, proposal, rng, chain_index):
     xi[accept_idx] = xi_hat[accept_idx]
     xi[~accept_idx] = current_state[~accept_idx]
 
-    return {"x": xi, "rng": rng}
+    mcmc_accept_rate = np.mean(accept_idx)
+
+    return {"x": xi, "mcmc_accept_rate": mcmc_accept_rate, "rng": rng}

--- a/matflow/data/scripts/uq/generate_next_state.py
+++ b/matflow/data/scripts/uq/generate_next_state.py
@@ -2,8 +2,7 @@ import logging
 import os
 
 import numpy as np
-from numpy.typing import NDArray
-from scipy.stats import norm
+import scipy.stats
 
 
 def set_up_logger():
@@ -35,15 +34,16 @@ def _init_rng(chain_index, loop_idx):
     return rng
 
 
-def generate_next_state(x, prop_std, rng, chain_index):
+def generate_next_state(x, proposal, rng, chain_index):
     """Generate the next candidate state in a modified Metropolis algorithm.
 
     Parameters
     ----------
     x
         Current state on which the candidate state will depend.
-    prop_std
-        Proposal distribution standard deviation.
+    proposal
+        Type and arguments to a Scipy distribution that should be used as the proposal.
+        The proposal must be a symmetrical distribution, centred on zero.
     rng
         Random number generator to be used in this function.
     chain_index
@@ -58,6 +58,9 @@ def generate_next_state(x, prop_std, rng, chain_index):
             Random number generator to be used in the next invocation of this function,
             for this chain.
     """
+
+    dist_type = proposal.pop("type")
+    prop_dist = getattr(scipy.stats, dist_type)(**proposal)
 
     loop_idx = {
         loop_name: int(loop_idx)
@@ -76,9 +79,8 @@ def generate_next_state(x, prop_std, rng, chain_index):
     current_state = x
     xi = np.empty(dim)
 
-    proposal = norm(loc=current_state, scale=prop_std)
-    xi_hat = np.atleast_1d(proposal.rvs(random_state=rng))
-    accept_ratios = np.divide(*norm.pdf([xi_hat, current_state]))
+    xi_hat = np.atleast_1d(current_state + prop_dist.rvs(size=dim, random_state=rng))
+    accept_ratios = np.divide(*scipy.stats.norm.pdf([xi_hat, current_state]))
     accept_idx = rng.random(len(accept_ratios)) < np.minimum(1, accept_ratios)
 
     xi[accept_idx] = xi_hat[accept_idx]

--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -1886,7 +1886,7 @@
 - objective: generate_next_state
   inputs:
     - parameter: x
-    - parameter: prop_std
+    - parameter: proposal
     - parameter: chain_index
     - parameter: rng
       default_value: null

--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -1807,7 +1807,7 @@
       group: all
       default_value: null
     - parameter: level_cov
-      default_value: null      
+      default_value: null
     - parameter: p_0
   outputs:
     - parameter: chain_seeds
@@ -1826,6 +1826,7 @@
       script_data_in:
         g: { format: direct, all_iterations: true }
         level_cov: { format: direct, all_iterations: true }
+        all_accept: { format: direct, all_iterations: true }
         "*": direct
       script_data_out: direct
       script_exe: python_script
@@ -1892,6 +1893,7 @@
       default_value: null
   outputs:
     - parameter: x
+    - parameter: mcmc_accept_rate
     - parameter: rng
   actions:
     - script: <<script:uq/generate_next_state.py>>
@@ -1910,7 +1912,7 @@
     - parameter: prop_std
     - parameter: chain_index
     - parameter: rng
-      default_value: null    
+      default_value: null
   outputs:
     - parameter: x
     - parameter: rng
@@ -1932,7 +1934,7 @@
     - parameter: lambda_
     - parameter: chain_index
     - parameter: rng
-      default_value: null    
+      default_value: null
   outputs:
     - parameter: x
     - parameter: rng

--- a/matflow/data/workflows/subset_simulation_DAMASK_Al.yaml
+++ b/matflow/data/workflows/subset_simulation_DAMASK_Al.yaml
@@ -117,7 +117,9 @@ tasks:
           step: 1
   - schema: generate_next_state # [inner loop]
     inputs:
-      prop_std: 0.5
+      proposal:
+        type: norm
+        scale: 0.5
   - schema: system_analysis # [inner loop]
   - schema: increment_chain # [inner loop]
     groups:

--- a/matflow/data/workflows/subset_simulation_DAMASK_Mg.yaml
+++ b/matflow/data/workflows/subset_simulation_DAMASK_Mg.yaml
@@ -256,7 +256,9 @@ tasks:
           step: 1
   - schema: generate_next_state # [inner loop]
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
   - schema: system_analysis # [inner loop]
   - schema: increment_chain # [inner loop]
     groups:

--- a/matflow/data/workflows/subset_simulation_DAMASK_Mg_two_level.yaml
+++ b/matflow/data/workflows/subset_simulation_DAMASK_Mg_two_level.yaml
@@ -476,7 +476,9 @@ tasks:
 
   - schema: generate_next_state # [inner MC loop; outer MC loop] # 6
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
   - schema: system_analysis_16 # [inner MC loop; outer MC loop] # 7,8,9
   - schema: increment_chain_inner # [inner MC loop; outer MC loop] # outputs x, like `generate_next_state` does # 10
 

--- a/matflow/data/workflows/subset_simulation_toy_model.yaml
+++ b/matflow/data/workflows/subset_simulation_toy_model.yaml
@@ -1,9 +1,9 @@
 loops:
   - name: markov_chain_state # [inner loop]
-    tasks: [4, 5, 6]
+    tasks: [ 4, 5, 6 ]
     num_iterations: 9 # num_states - 1: (1 / p_0) - 1
   - name: levels # [outer loop]
-    tasks: [2, 3, 4, 5, 6]
+    tasks: [ 2, 3, 4, 5, 6 ]
     num_iterations: 7
     termination_task: 2
     termination:
@@ -26,7 +26,7 @@ tasks:
   - schema: system_analysis_toy_model
     inputs:
       dimension: 200
-      target_pf: 1.0e-4
+      target_pf: 1e-4
     groups:
       - name: all
   - schema: collate_results # [outer loop]
@@ -41,11 +41,13 @@ tasks:
           step: 1
   - schema: generate_next_state # [inner loop]
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
   - schema: system_analysis_toy_model # [inner loop]
     inputs:
       dimension: 200
-      target_pf: 1.0e-4
+      target_pf: 1e-4
   - schema: increment_chain # [inner loop]
     groups:
       - name: all

--- a/matflow/data/workflows/subset_simulation_toy_model_delayed_acceptance.yaml
+++ b/matflow/data/workflows/subset_simulation_toy_model_delayed_acceptance.yaml
@@ -47,7 +47,9 @@ tasks:
 
   - schema: generate_next_state # [inner MC loop; outer MC loop]
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
 
   - schema: system_analysis_DA_coarse # [inner MC loop; outer MC loop]
     resources:

--- a/matflow/data/workflows/subset_simulation_toy_model_external.yaml
+++ b/matflow/data/workflows/subset_simulation_toy_model_external.yaml
@@ -53,7 +53,9 @@ tasks:
           step: 1
   - schema: generate_next_state # [inner loop]
     inputs:
-      prop_std: 0.5
+      proposal:
+        type: norm
+        scale: 0.5
   - schema: system_analysis # [inner loop]
   - schema: increment_chain # [inner loop]
     groups:

--- a/matflow/data/workflows/subset_simulation_toy_model_two_level.yaml
+++ b/matflow/data/workflows/subset_simulation_toy_model_two_level.yaml
@@ -45,7 +45,9 @@ tasks:
 
   - schema: generate_next_state # [inner MC loop; outer MC loop]
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
   - schema: system_analysis_toy_model # [inner MC loop; outer MC loop]
     inputs:
       dimension: 200

--- a/matflow/data/workflows/subset_simulation_toy_model_two_level_external.yaml
+++ b/matflow/data/workflows/subset_simulation_toy_model_two_level_external.yaml
@@ -59,7 +59,9 @@ tasks:
 
   - schema: generate_next_state # [inner MC loop; outer MC loop] # 6
     inputs:
-      prop_std: 1.0
+      proposal:
+        type: norm
+        scale: 1.0
   - schema: system_analysis # [inner MC loop; outer MC loop] # 7,8,9
   - schema: increment_chain_inner # [inner MC loop; outer MC loop] # outputs x, like `generate_next_state` does # 10
 

--- a/matflow/tests/demo_workflows/test_demo_workflows.py
+++ b/matflow/tests/demo_workflows/test_demo_workflows.py
@@ -70,12 +70,8 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
         path=tmp_path,
         status=False,
         add_to_known=False,
-        wait=True,
         resources={"random_seed": seed},
     )
-    final_iter = wk.tasks.collate_results.elements[0].latest_iteration_non_skipped
-    pf = final_iter.get("outputs.pf")
-    cov = final_iter.get("outputs.cov")
 
     # run via single function implementation:
     pf_sf, cov_sf = subset_simulation(
@@ -91,6 +87,14 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
         master_seed=seed,
         mimic_matflow=True,
     )
+
+    wk.wait()
+    final_iter = wk.tasks.collate_results.elements[0].latest_iteration_non_skipped
+    pf = final_iter.get("outputs.pf")
+    cov = final_iter.get("outputs.cov")
+
+    # TODO: also verify same result with `subset_simulation_toy_model_external`, once
+    # that can be submitted without a ridiculous number of processes.
 
     assert pf == pf_sf
     assert cov == cov_sf

--- a/matflow/tests/demo_workflows/test_demo_workflows.py
+++ b/matflow/tests/demo_workflows/test_demo_workflows.py
@@ -3,6 +3,7 @@ import pytest
 
 from scipy.stats import norm
 from hpcflow.sdk.core.enums import EARStatus
+import numpy as np
 
 import matflow as mf
 from matflow.tests.subset_simulation import subset_simulation, generate_next_level_samples
@@ -74,7 +75,7 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
     )
 
     # run via single function implementation:
-    pf_sf, cov_sf = subset_simulation(
+    pf_sf, cov_sf, sus_acc_sf, mcmc_acc_sf = subset_simulation(
         dimension=200,
         target_pf=1e-4,
         p_0=0.1,
@@ -92,9 +93,12 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
     final_iter = wk.tasks.collate_results.elements[0].latest_iteration_non_skipped
     pf = final_iter.get("outputs.pf")
     cov = final_iter.get("outputs.cov")
+    sus_acc = final_iter.get("outputs.accept_rate")[:]
 
     # TODO: also verify same result with `subset_simulation_toy_model_external`, once
     # that can be submitted without a ridiculous number of processes.
 
     assert pf == pf_sf
     assert cov == cov_sf
+    assert np.allclose(sus_acc, sus_acc_sf)
+    # TODO: store and check mcmc_accept

--- a/matflow/tests/demo_workflows/test_demo_workflows.py
+++ b/matflow/tests/demo_workflows/test_demo_workflows.py
@@ -3,7 +3,7 @@ import pytest
 from hpcflow.sdk.core.enums import EARStatus
 
 import matflow as mf
-from matflow.tests.subset_simulation import generate_next_state, subset_simulation
+from matflow.tests.subset_simulation import subset_simulation, generate_next_level_samples
 
 
 @pytest.mark.demo_workflows
@@ -82,8 +82,8 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
         p_0=0.1,
         num_samples=100,
         num_levels=7,
-        next_state=generate_next_state,
-        next_state_kwargs={
+        sampling_method=generate_next_level_samples,
+        sampling_method_kwargs={
             "prop_std": 1.0,
         },
         master_seed=seed,

--- a/matflow/tests/demo_workflows/test_demo_workflows.py
+++ b/matflow/tests/demo_workflows/test_demo_workflows.py
@@ -1,5 +1,7 @@
 from matplotlib import pyplot as plt
 import pytest
+
+from scipy.stats import norm
 from hpcflow.sdk.core.enums import EARStatus
 
 import matflow as mf
@@ -84,7 +86,7 @@ def test_subset_simulation_toy_model_prediction(tmp_path):
         num_levels=7,
         sampling_method=generate_next_level_samples,
         sampling_method_kwargs={
-            "prop_std": 1.0,
+            "proposal": norm(scale=1.0),
         },
         master_seed=seed,
         mimic_matflow=True,

--- a/matflow/tests/subset_simulation.py
+++ b/matflow/tests/subset_simulation.py
@@ -116,10 +116,124 @@ def generate_next_state_CS(x, prop_std, rng):
     return norm.rvs(loc=x * rho, scale=prop_std, random_state=rng)
 
 
-def generate_next_state_ACS(x, prop_std, lambda_, rng):
+def generate_next_state_ACS(x, prop_std, lambda_, sims_per_update, rng):
+    """
+    Parameters
+    ----------
+    sims_per_update
+        The number of simulations that will run before lambda_ is updated. Known as `Na`
+        elsewhere.
+    """
+    a_star = 0.44
     sigma = np.minimum(1, lambda_ * prop_std)
     rho = np.sqrt(1 - sigma**2)
     return norm.rvs(loc=x * rho, scale=sigma, random_state=rng)
+
+
+def generate_next_level_samples(
+    num_chains,
+    num_states,
+    dimension,
+    chain_seeds,
+    chain_g,
+    all_x,
+    all_g,
+    level_idx,
+    master_seed,
+    target_pf,
+    threshold,
+    prop_std,
+):
+
+    for chain_index in range(num_chains):
+
+        # proceed this Markov chain until all states have been generated
+        all_x[chain_index, 0] = chain_seeds[chain_index]
+        all_g[chain_index, 0] = chain_g[chain_index]
+
+        chain_rng = None
+        for state_idx in range(1, num_states):
+
+            # RNG seed sequence for Markov chains:
+            if state_idx == 1:
+                # spawn key to match the task ID in the matflow workflow
+                spawn_key = (4, level_idx, chain_index)
+                chain_rng = np.random.default_rng(
+                    np.random.SeedSequence(master_seed, spawn_key=spawn_key)
+                )
+
+            x = all_x[chain_index, state_idx - 1]
+            g = all_g[chain_index, state_idx - 1]
+
+            trial_x = generate_next_state(
+                x=x,
+                prop_std=prop_std,
+                rng=chain_rng,
+            )
+            trial_g = system_analysis_toy_model(trial_x, dimension, target_pf=target_pf)
+
+            current_x = x
+            current_g = g
+
+            is_accept = trial_g > threshold
+            new_x = trial_x if is_accept else current_x
+            new_g = trial_g if is_accept else current_g
+
+            all_x[chain_index, state_idx] = new_x
+            all_g[chain_index, state_idx] = new_g
+
+
+def generate_next_level_samples_CS(
+    num_chains,
+    num_states,
+    dimension,
+    chain_seeds,
+    chain_g,
+    all_x,
+    all_g,
+    level_idx,
+    master_seed,
+    target_pf,
+    threshold,
+    prop_std,
+):
+
+    for chain_index in range(num_chains):
+
+        # proceed this Markov chain until all states have been generated
+        all_x[chain_index, 0] = chain_seeds[chain_index]
+        all_g[chain_index, 0] = chain_g[chain_index]
+
+        chain_rng = None
+        for state_idx in range(1, num_states):
+
+            # RNG seed sequence for Markov chains:
+            if state_idx == 1:
+                # spawn key to match the task ID in the matflow workflow
+                spawn_key = (4, level_idx, chain_index)
+                chain_rng = np.random.default_rng(
+                    np.random.SeedSequence(master_seed, spawn_key=spawn_key)
+                )
+
+            x = all_x[chain_index, state_idx - 1]
+            g = all_g[chain_index, state_idx - 1]
+
+            trial_x = generate_next_state_CS(
+                x=x,
+                prop_std=prop_std,
+                rng=chain_rng,
+            )
+            trial_g = system_analysis_toy_model(trial_x, dimension, target_pf=target_pf)
+
+            current_x = x
+            current_g = g
+
+            is_accept = trial_g > threshold
+            new_x = trial_x if is_accept else current_x
+            new_g = trial_g if is_accept else current_g
+
+            all_x[chain_index, state_idx] = new_x
+            all_g[chain_index, state_idx] = new_g
 
 
 def subset_simulation(
@@ -129,8 +243,8 @@ def subset_simulation(
     num_samples=100,
     num_levels=10,
     master_seed=None,
-    next_state=generate_next_state,
-    next_state_kwargs=None,
+    sampling_method=generate_next_level_samples,
+    sampling_method_kwargs=None,
     mimic_matflow: bool = False,
 ):
 
@@ -179,47 +293,20 @@ def subset_simulation(
 
         all_x = np.ones((num_chains, num_states, dimension)) * np.nan
         all_g = np.ones((num_chains, num_states)) * np.nan
-
-        for chain_index in range(num_chains):
-
-            # proceed this Markov chain until all states have been generated
-            all_x[chain_index, 0] = chain_seeds[chain_index]
-            all_g[chain_index, 0] = chain_g[chain_index]
-
-            chain_rng = None
-            for state_idx in range(1, num_states):
-
-                # RNG seed sequence for Markov chains:
-                if state_idx == 1:
-                    # spawn key to match the task ID in the matflow workflow
-                    spawn_key = (4, level_idx, chain_index)
-                    chain_rng = np.random.default_rng(
-                        np.random.SeedSequence(master_seed, spawn_key=spawn_key)
-                    )
-
-                x = all_x[chain_index, state_idx - 1]
-                g = all_g[chain_index, state_idx - 1]
-
-                next_state_kwargs_i = {
-                    "x": x,
-                    "rng": chain_rng,
-                    **(next_state_kwargs or {}),
-                }
-                trial_x = next_state(**next_state_kwargs_i)
-                trial_g = system_analysis_toy_model(
-                    trial_x, dimension, target_pf=target_pf
-                )
-
-                current_x = x
-                current_g = g
-
-                is_accept = trial_g > threshold
-                new_x = trial_x if is_accept else current_x
-                new_g = trial_g if is_accept else current_g
-
-                all_x[chain_index, state_idx] = new_x
-                all_g[chain_index, state_idx] = new_g
-
+        sampling_method(
+            num_chains=num_chains,
+            num_states=num_states,
+            dimension=dimension,
+            chain_seeds=chain_seeds,
+            chain_g=chain_g,
+            all_x=all_x,
+            all_g=all_g,
+            level_idx=level_idx,
+            master_seed=master_seed,
+            target_pf=target_pf,
+            threshold=threshold,
+            **sampling_method_kwargs,
+        )
         g = all_g.reshape((num_samples))
         x = all_x.reshape((num_samples, dimension))
 
@@ -267,8 +354,8 @@ def run_repeats(
             p_0=p_0,
             num_samples=num_samples,
             num_levels=num_levels,
-            next_state=next_state,
-            next_state_kwargs=next_state_kwargs,
+            sampling_method=next_state,
+            sampling_method_kwargs=next_state_kwargs,
             master_seed=seeds[repeat_idx],
             mimic_matflow=mimic_matflow,
         )

--- a/matflow/tests/subset_simulation.py
+++ b/matflow/tests/subset_simulation.py
@@ -7,9 +7,11 @@ from pathlib import Path
 
 from matplotlib import pyplot as plt
 import numpy as np
-from scipy.stats import norm, multivariate_normal
+from scipy.stats import norm, multivariate_normal, uniform
 from numpy.exceptions import AxisError
 from hpcflow.sdk.log import TimeIt
+
+import matflow as mf
 
 
 @TimeIt.decorator
@@ -91,17 +93,17 @@ def estimate_cov(indicator, p_i: float) -> float:
     return delta
 
 
-def generate_next_state(x, prop_std, rng):
+def generate_next_state(x, proposal, rng):
+    """
+    Proposal must be a symmetric distribution centred on zero.
+    """
 
     dim = len(x)
     current_state = x
     xi = np.empty(dim)
 
-    proposal = norm(loc=current_state, scale=prop_std)
-    xi_hat = np.atleast_1d(proposal.rvs(random_state=rng))
-
+    xi_hat = np.atleast_1d(current_state + proposal.rvs(size=dim, random_state=rng))
     accept_ratios = np.divide(*norm.pdf([xi_hat, current_state]))
-    # accept_ratios = np.exp(-0.5 * (xi_hat**2 - current_state**2))
 
     accept_idx = rng.random(len(accept_ratios)) < np.minimum(1, accept_ratios)
 
@@ -142,7 +144,7 @@ def generate_next_level_samples(
     master_seed,
     target_pf,
     threshold,
-    prop_std,
+    proposal,
 ):
 
     for chain_index in range(num_chains):
@@ -167,7 +169,7 @@ def generate_next_level_samples(
 
             trial_x = generate_next_state(
                 x=x,
-                prop_std=prop_std,
+                proposal=proposal,
                 rng=chain_rng,
             )
             trial_g = system_analysis_toy_model(trial_x, dimension, target_pf=target_pf)
@@ -330,8 +332,8 @@ def get_stats(all_pf, all_cov):
 
 def run_repeats(
     num_samples,
-    next_state,
-    next_state_kwargs=None,
+    sampling_method,
+    sampling_method_kwargs=None,
     num_repeats=100,
     dimension=200,
     target_pf=1e-4,
@@ -354,8 +356,8 @@ def run_repeats(
             p_0=p_0,
             num_samples=num_samples,
             num_levels=num_levels,
-            sampling_method=next_state,
-            sampling_method_kwargs=next_state_kwargs,
+            sampling_method=sampling_method,
+            sampling_method_kwargs=sampling_method_kwargs,
             master_seed=seeds[repeat_idx],
             mimic_matflow=mimic_matflow,
         )
@@ -365,12 +367,20 @@ def run_repeats(
     return get_stats(all_pf, all_cov)
 
 
+def dist_to_str(dist):
+    """Return a string representation of a distribution."""
+    args = ",".join(
+        [str(i) for i in dist.args] + [f"{k}={v}" for k, v in dist.kwds.items()]
+    )
+    return f"{dist.dist.name}({args})"
+
+
 def run_convergence(
     converge_label: str,
     fixed_num: int,
     series: list[int],
-    next_state,
-    next_state_kwargs: dict,
+    sampling_method: callable,
+    sampling_method_kwargs: dict,
     mimic_matflow: bool,
 ):
     """Run a convergence test on the toy model subset simulation, for either number of samples per level, N, or number of repeats, R.
@@ -394,16 +404,16 @@ def run_convergence(
     )
     direct_results = {
         "data": {},
-        "next_state": next_state.__name__,
-        "next_state_kwargs": next_state_kwargs,
+        "sampling_method": sampling_method.__name__,
+        "sampling_method_kwargs": sampling_method_kwargs,
         "converge_label": converge_label,
         "fixed_num": fixed_num,
         "series": series,
     }
     for num in series:
         run_kwargs_i = {
-            "next_state": next_state,
-            "next_state_kwargs": next_state_kwargs,
+            "sampling_method": sampling_method,
+            "sampling_method_kwargs": sampling_method_kwargs,
             "mimic_matflow": mimic_matflow,
         }
         if converge_label == "N":
@@ -414,8 +424,13 @@ def run_convergence(
             run_kwargs_i["num_samples"] = fixed_num
         direct_results["data"][num] = run_repeats(**run_kwargs_i)
 
+    if "proposal" in sampling_method_kwargs:
+        prop_str = dist_to_str(sampling_method_kwargs["proposal"])
+    else:
+        prop_str = f"{sampling_method_kwargs['prop_std']:.2f}"
+
     timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    file_name = f"toy_model_runs_{converge_label}_converge_{fixed_str}_{next_state.__name__}_std{next_state_kwargs['prop_std']:.2f}_mimic{str(int(mimic_matflow))}_{timestamp}.pkl"
+    file_name = f"toy_model_runs_{converge_label}_converge_{fixed_str}_{sampling_method.__name__}_std{prop_str}_mimic{str(int(mimic_matflow))}_{timestamp}.pkl"
     with Path(file_name).open("wb") as fh:
         pickle.dump(direct_results, fh)
 
@@ -441,7 +456,101 @@ def get_toy_model_results_from_matflow_workflows(root_path):
     return get_stats(all_pf, all_cov)
 
 
-def plot_pf_num_samples(all_results, quantile_range):
+def plot_many_pf_num_samples_from_files(pkls, quantile_range=0.95, yscale="log"):
+    results = {}
+    for label, pkl in pkls.items():
+        with Path(pkl).open("rb") as fh:
+            results[label] = pickle.load(fh)
+    plot_many_pf_num_samples(results, quantile_range=quantile_range, yscale=yscale)
+
+
+def plot_many_pf_num_samples(
+    all_results_dct,
+    quantile_range,
+    xlim=None,
+    xscale="linear",
+    ylim=None,
+    yscale="linear",
+    target_pf=1e-4,
+):
+
+    plt.figure(figsize=(5, 4))
+
+    all_x = {k: [] for k in all_results_dct.keys()}
+    all_y = {k: [] for k in all_results_dct.keys()}
+    all_lower = {k: [] for k in all_results_dct.keys()}
+    all_upper = {k: [] for k in all_results_dct.keys()}
+
+    polys = []
+
+    for idx, (label, all_results) in enumerate(all_results_dct.items()):
+
+        if idx == 0:
+            converge_label = all_results["converge_label"]
+            fixed_num = all_results["fixed_num"]
+            title = f"{'num_repeats' if converge_label == 'N' else 'num_samples'}={fixed_num!r}"
+            xlabel = "Num samples, N" if converge_label == "N" else "Num repeats, R"
+        else:
+            assert all_results["converge_label"] == converge_label
+            assert all_results["fixed_num"] == fixed_num
+
+        all_data = all_results["data"]
+        for N, data in all_data.items():
+            pf_srt = sorted(data["pf"])
+            _x0 = (1 - quantile_range) / 2
+            _x1 = _x0 + quantile_range
+            lower = np.quantile(pf_srt, _x0)
+            upper = np.quantile(pf_srt, _x1)
+
+            all_x[label].append(N)
+            all_y[label].append(data["pf_mean"])
+            all_lower[label].append(lower)
+            all_upper[label].append(upper)
+
+        polys.append(
+            plt.fill_between(
+                x=all_x[label],
+                y1=all_lower[label],
+                y2=all_upper[label],
+                alpha=0.5,
+                label=label,
+            )
+        )
+
+    for idx, (label, all_results) in enumerate(all_results_dct.items()):
+        all_data = all_results["data"]
+        plt.scatter(
+            x=all_x[label],
+            y=all_y[label],
+            marker="o",
+            color=polys[idx].get_facecolor()[0],
+            edgecolor="black",
+            linewidth=0.8,
+            zorder=3,
+        )
+
+    plt.hlines(
+        y=target_pf,
+        xmin=min(all_data),
+        xmax=max(all_data),
+        color="gray",
+        label="Target",
+    )
+    plt.xlabel(xlabel)
+    plt.ylabel("Prob. of failure, pf")
+    plt.title(title)
+    plt.legend()
+    if ylim:
+        plt.ylim(ylim)
+    if xlim:
+        plt.xlim(xlim)
+    plt.yscale(yscale)
+    plt.xscale(xscale)
+
+
+def plot_pf_num_samples(
+    all_results, quantile_range, xlim=None, xscale="linear", ylim=None, yscale="linear"
+):
 
     converge_label = all_results["converge_label"]
     fixed_num = all_results["fixed_num"]
@@ -475,15 +584,19 @@ def plot_pf_num_samples(all_results, quantile_range):
     plt.hlines(
         y=1e-4, xmin=min(all_data), xmax=max(all_data), color="gray", label="Target"
     )
-    # plt.xscale("log")
-    # plt.yscale("log")
     plt.xlabel(xlabel)
     plt.ylabel("Prob. of failure, pf")
     plt.title(title)
     plt.legend()
+    if ylim:
+        plt.ylim(ylim)
+    if xlim:
+        plt.xlim(xlim)
+    plt.yscale(yscale)
+    plt.xscale(xscale)
 
 
-def plot_cov_estimates(all_results, ylim=None):
+def plot_cov_estimates(all_results, ylim=None, yscale="linear"):
 
     converge_label = all_results["converge_label"]
     fixed_num = all_results["fixed_num"]
@@ -511,6 +624,7 @@ def plot_cov_estimates(all_results, ylim=None):
     plt.legend()
     if ylim:
         plt.ylim(ylim)
+    plt.yscale(yscale)
 
 
 def plot_pf_dist(all_results, target_pf):

--- a/matflow/tests/subset_simulation.py
+++ b/matflow/tests/subset_simulation.py
@@ -1,6 +1,7 @@
 """Module containing functions to run a subset simulation on a simple toy model, used as a
 validation of the MatFlow implementation."""
 
+import copy
 from datetime import datetime
 import pickle
 from pathlib import Path
@@ -109,8 +110,9 @@ def generate_next_state(x, proposal, rng):
 
     xi[accept_idx] = xi_hat[accept_idx]
     xi[~accept_idx] = current_state[~accept_idx]
+    mcmc_accept_rate = np.mean(accept_idx)
 
-    return xi
+    return xi, mcmc_accept_rate
 
 
 def generate_next_state_CS(x, prop_std, rng):
@@ -118,14 +120,7 @@ def generate_next_state_CS(x, prop_std, rng):
     return norm.rvs(loc=x * rho, scale=prop_std, random_state=rng)
 
 
-def generate_next_state_ACS(x, prop_std, lambda_, sims_per_update, rng):
-    """
-    Parameters
-    ----------
-    sims_per_update
-        The number of simulations that will run before lambda_ is updated. Known as `Na`
-        elsewhere.
-    """
+def generate_next_state_ACS(x, prop_std, lambda_, rng):
     a_star = 0.44
     sigma = np.minimum(1, lambda_ * prop_std)
     rho = np.sqrt(1 - sigma**2)
@@ -147,6 +142,9 @@ def generate_next_level_samples(
     proposal,
 ):
 
+    subset_accept_arr = np.zeros((num_chains, num_states - 1)).astype(bool)
+    mcmc_accept_arr = np.zeros((num_chains, num_states - 1))
+
     for chain_index in range(num_chains):
 
         # proceed this Markov chain until all states have been generated
@@ -167,22 +165,27 @@ def generate_next_level_samples(
             x = all_x[chain_index, state_idx - 1]
             g = all_g[chain_index, state_idx - 1]
 
-            trial_x = generate_next_state(
+            trial_x, mcmc_accept_rate = generate_next_state(
                 x=x,
                 proposal=proposal,
                 rng=chain_rng,
             )
+            mcmc_accept_arr[chain_index, state_idx - 1] = mcmc_accept_rate
             trial_g = system_analysis_toy_model(trial_x, dimension, target_pf=target_pf)
 
             current_x = x
             current_g = g
-
-            is_accept = trial_g > threshold
-            new_x = trial_x if is_accept else current_x
-            new_g = trial_g if is_accept else current_g
+            is_ss_accept = trial_g > threshold
+            subset_accept_arr[chain_index, state_idx - 1] = is_ss_accept
+            new_x = trial_x if is_ss_accept else current_x
+            new_g = trial_g if is_ss_accept else current_g
 
             all_x[chain_index, state_idx] = new_x
             all_g[chain_index, state_idx] = new_g
+
+    subset_accept = np.mean(subset_accept_arr).item()
+    mcmc_accept = np.mean(mcmc_accept_arr).item()
+    return {"subset_accept": subset_accept, "mcmc_accept": mcmc_accept}
 
 
 def generate_next_level_samples_CS(
@@ -199,7 +202,11 @@ def generate_next_level_samples_CS(
     threshold,
     prop_std,
 ):
+    """Conditional sampling algorithm for generating states in the subset simulation level
+    (aka subset infinity).
 
+    """
+    subset_accept_arr = np.zeros((num_chains, num_states - 1)).astype(bool)
     for chain_index in range(num_chains):
 
         # proceed this Markov chain until all states have been generated
@@ -231,11 +238,111 @@ def generate_next_level_samples_CS(
             current_g = g
 
             is_accept = trial_g > threshold
+            subset_accept_arr[chain_index, state_idx - 1] = is_accept
             new_x = trial_x if is_accept else current_x
             new_g = trial_g if is_accept else current_g
 
             all_x[chain_index, state_idx] = new_x
             all_g[chain_index, state_idx] = new_g
+
+    subset_accept = np.mean(subset_accept_arr).item()
+    return {"subset_accept": subset_accept}
+
+
+def generate_next_level_samples_ACS(
+    num_chains,
+    num_states,
+    dimension,
+    chain_seeds,
+    chain_g,
+    all_x,
+    all_g,
+    level_idx,
+    master_seed,
+    target_pf,
+    threshold,
+    chains_per_update,
+    prop_std=1.0,
+    lambda_=1.0,
+):
+    """Adaptive conditional sampling algorithm for generating states in the subset
+    simulation level (aka adaptive subset infinity).
+
+    Parameters
+    ----------
+    chains_per_update
+        The number of Markov chains (as a fraction of the number of samples per level)
+        that will run before lambda_ is updated. As an integer number, known as `Na`
+        elsewhere.
+    prop_std
+        Initial variance of the proposal distribution.
+    lambda_
+        Initial scaling parameter.
+
+    """
+
+    A_STAR = 0.44
+
+    num_chains_per_update = int(chains_per_update * num_chains)
+    assert float(num_chains_per_update) == chains_per_update * num_chains
+
+    num_batches = int(num_chains / num_chains_per_update)
+    batch_avgs = []  # mean acceptance for each batch
+
+    for batch_idx in range(num_batches):
+
+        sigma = np.minimum(1, lambda_ * prop_std)
+        rho = np.sqrt(1 - sigma**2)
+
+        is_accept_arr = np.zeros((num_chains_per_update, num_states - 1)).astype(bool)
+        for batch_chain_idx in range(num_chains_per_update):
+
+            chain_index = batch_chain_idx + (batch_idx * num_chains_per_update)
+
+            # proceed this Markov chain until all states have been generated
+            all_x[chain_index, 0] = chain_seeds[chain_index]
+            all_g[chain_index, 0] = chain_g[chain_index]
+
+            chain_rng = None
+            for state_idx in range(1, num_states):
+
+                # RNG seed sequence for Markov chains:
+                if state_idx == 1:
+                    # spawn key to match the task ID in the matflow workflow
+                    spawn_key = (4, level_idx, chain_index)
+                    chain_rng = np.random.default_rng(
+                        np.random.SeedSequence(master_seed, spawn_key=spawn_key)
+                    )
+
+                x = all_x[chain_index, state_idx - 1]
+                g = all_g[chain_index, state_idx - 1]
+
+                trial_x = norm.rvs(loc=x * rho, scale=sigma, random_state=chain_rng)
+
+                trial_g = system_analysis_toy_model(
+                    trial_x, dimension, target_pf=target_pf
+                )
+
+                current_x = x
+                current_g = g
+
+                is_accept = trial_g > threshold
+                is_accept_arr[batch_chain_idx, state_idx - 1] = is_accept
+
+                new_x = trial_x if is_accept else current_x
+                new_g = trial_g if is_accept else current_g
+
+                all_x[chain_index, state_idx] = new_x
+                all_g[chain_index, state_idx] = new_g
+
+        accept_batch_avg = np.mean(is_accept_arr)
+        batch_avgs.append(accept_batch_avg)
+
+        zeta = 1 / np.sqrt(batch_idx + 1)
+        lambda_ *= np.exp(zeta * (accept_batch_avg - A_STAR))
+
+    subset_accept = np.mean(batch_avgs).item()
+    return {"lambda_": lambda_, "subset_accept": subset_accept}
 
 
 def subset_simulation(
@@ -258,8 +365,12 @@ def subset_simulation(
         mimic_matflow=mimic_matflow,
     )
     g = system_analysis_toy_model(x, dimension, target_pf=target_pf)
+    sampling_method_kwargs = copy.deepcopy(sampling_method_kwargs)
 
     level_covs = []
+    subset_accepts = []
+    mcmc_accepts = []
+    ret = None
     for level_idx in range(num_levels):
         num_failed = int(np.sum(g > 0))
         num_chains = int(len(g) * p_0)
@@ -291,11 +402,11 @@ def subset_simulation(
 
         if is_finished := threshold > 0:
             cov = np.sqrt(sum(np.pow(level_covs, 2))).item()
-            return pf, cov
+            return pf, cov, subset_accepts, mcmc_accepts
 
         all_x = np.ones((num_chains, num_states, dimension)) * np.nan
         all_g = np.ones((num_chains, num_states)) * np.nan
-        sampling_method(
+        ret = sampling_method(
             num_chains=num_chains,
             num_states=num_states,
             dimension=dimension,
@@ -309,8 +420,18 @@ def subset_simulation(
             threshold=threshold,
             **sampling_method_kwargs,
         )
+        subset_accepts.append(ret["subset_accept"])
+
+        if "mcmc_accept" in (ret or {}):
+            mcmc_accepts.append(ret["mcmc_accept"])
+
+        if "lambda_" in (ret or {}):
+            sampling_method_kwargs["lambda_"] = ret["lambda_"]
+
         g = all_g.reshape((num_samples))
         x = all_x.reshape((num_samples, dimension))
+
+    raise RuntimeError(f"Failed to estimate in {num_levels} levels. Try increasing.")
 
 
 def get_stats(all_pf, all_cov):
@@ -425,16 +546,22 @@ def run_convergence(
         direct_results["data"][num] = run_repeats(**run_kwargs_i)
 
     if "proposal" in sampling_method_kwargs:
-        prop_str = dist_to_str(sampling_method_kwargs["proposal"])
+        kwargs_str = dist_to_str(sampling_method_kwargs["proposal"])
     else:
-        prop_str = f"{sampling_method_kwargs['prop_std']:.2f}"
+        kwargs_str = f"{sampling_method_kwargs['prop_std']:.2f}"
+
+    if "chains_per_update" in sampling_method_kwargs:
+        kwargs_str += f"_NaFrac{sampling_method_kwargs['chains_per_update']:.1f}"
+
+    if "lambda_" in sampling_method_kwargs:
+        kwargs_str += f"_lambda{sampling_method_kwargs['lambda_']:.2f}"
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
-    file_name = f"toy_model_runs_{converge_label}_converge_{fixed_str}_{sampling_method.__name__}_std{prop_str}_mimic{str(int(mimic_matflow))}_{timestamp}.pkl"
+    file_name = f"toy_model_runs_{converge_label}_converge_{fixed_str}_{sampling_method.__name__}_std{kwargs_str}_mimic{str(int(mimic_matflow))}_{timestamp}.pkl"
     with Path(file_name).open("wb") as fh:
         pickle.dump(direct_results, fh)
 
-    return direct_results
+    return file_name
 
 
 def get_toy_model_results_from_matflow_workflows(root_path):


### PR DESCRIPTION
This includes some improvements to all subset simulation variations. The ACS variant is fixed in the test function, but I came across some problems with loops that make it difficult to implement as a workflow currently. I will defer fixing that until I have some time to more closely to look at parameter propagation in nested loops in hpcflow.