### PR TITLE
Support VE generation using PyAPD

### DIFF
--- a/matflow/data/scripts/pyapd/generate_VE_PyAPD.py
+++ b/matflow/data/scripts/pyapd/generate_VE_PyAPD.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+import os
+from typing import Literal
+
+import numpy as np
+from numpy.typing import ArrayLike
+from damask_parse.utils import validate_volume_element, validate_orientations
+import PyAPD
+
+from matflow.param_classes.orientations import Orientations
+
+
+def generate_VE_PyAPD(
+    num_grains: int,
+    VE_grid_size: ArrayLike,
+    VE_size: ArrayLike,
+    phase_label: str,
+    homog_label: str,
+    orientations: Orientations | None,
+    random_seed: int | None | Literal["resource_value"] = "resource_value",
+):
+    if random_seed == "resource_value":
+        seed = int(os.environ["MATFLOW_RUN_RANDOM_SEED"])
+    else:
+        seed = random_seed
+
+    VE_size = np.asarray(VE_size)
+    VE_grid_size = np.asarray(VE_grid_size)
+
+    mat_idx, apd_obj = generate_voxel_microstructure(
+        grid_size=VE_grid_size,
+        n_grains=num_grains,
+        seed=seed,
+    )
+
+    oris = resolve_orientations(orientations, num_grains)
+    ori_idx = np.arange(num_grains)
+    const_phase_lab = np.array([phase_label])[np.zeros(num_grains, dtype=int)]
+
+    volume_element = {
+        "size": VE_size.tolist(),
+        "grid_size": VE_grid_size.tolist(),
+        "orientations": oris,
+        "element_material_idx": mat_idx,
+        "constituent_material_idx": np.arange(num_grains),
+        "constituent_material_fraction": np.ones(num_grains),
+        "constituent_phase_label": const_phase_lab,
+        "constituent_orientation_idx": ori_idx,
+        "material_homog": np.full(num_grains, homog_label),
+    }
+    volume_element = validate_volume_element(volume_element)
+    return {"volume_element": volume_element}
+
+
+def resolve_orientations(orientations, num_grains):
+    if orientations is None:
+        orientations = Orientations.from_random(num_grains)
+        assert orientations is not None
+
+    # see `LatticeDirection` enum:
+    align_lookup = {
+        "A": "a",
+        "B": "b",
+        "C": "c",
+        "A_STAR": "a*",
+        "B_STAR": "b*",
+        "C_STAR": "c*",
+    }
+    unit_cell_alignment = {
+        "x": align_lookup[orientations.unit_cell_alignment.x.name],
+        "y": align_lookup[orientations.unit_cell_alignment.y.name],
+        "z": align_lookup[orientations.unit_cell_alignment.z.name],
+    }
+    type_lookup = {
+        "QUATERNION": "quat",
+        "EULER": "euler",
+    }
+    type_ = type_lookup[orientations.representation.type.name]
+    oris = {
+        "type": type_,
+        "unit_cell_alignment": unit_cell_alignment,
+    }
+
+    if type_ == "quat":
+        quat_order = orientations.representation.quat_order.name.lower().replace("_", "-")
+        oris["quaternions"] = np.array(orientations.data)
+        oris["quat_component_ordering"] = quat_order
+    elif type_ == "euler":
+        oris["euler_angles"] = np.array(orientations.data)
+        oris["euler_degrees"] = orientations.representation.euler_is_degrees
+
+    return validate_orientations(oris)
+
+
+def generate_voxel_microstructure(
+    grid_size,
+    n_grains,
+    anisotropy=0.0,
+    optimize_weights=False,
+    lloyd_iterations=0,
+    seed=None,
+    heuristic_weights=True,
+    device=None,
+):
+    """
+    Generate a voxelized anisotropic power diagram microstructure using PyAPD.
+
+    Parameters
+    ----------
+    grid_size : tuple
+        Output voxel grid dimensions.
+        Examples:
+            (256,256)     -> 2D
+            (128,128,128) -> 3D
+
+    n_grains : int
+        Number of grains/seeds.
+
+    anisotropy : float
+        Controls anisotropy threshold.
+        0.0 = isotropic power diagram
+        1.0 = strong anisotropy allowed
+
+    optimize_weights : bool
+        If True, adjusts weights to improve volume balance.
+
+    lloyd_iterations : int
+        Number of Lloyd relaxation iterations.
+
+    seed : int or None
+        Random seed.
+
+    heuristic_weights : bool
+        Use PyAPD heuristic weight initialization.
+
+    device : str or None
+        "cpu" or "cuda".
+
+    Returns
+    -------
+    labels : ndarray
+        Integer grain labels with shape == grid_size.
+
+    apd : PyAPD.apd_system
+        Full APD object for further manipulation.
+    """
+
+    D = len(grid_size)
+
+    if D not in [2, 3]:
+        raise ValueError("grid_size must be 2D or 3D")
+
+    # Create APD system
+    apd = PyAPD.apd_system(
+        N=n_grains,
+        D=D,
+        heuristic_W=heuristic_weights,
+    )
+
+    # Optional reproducibility
+    if seed is not None:
+        apd.seed = seed
+
+    # Optional device selection
+    if device is not None:
+        apd.device = device
+
+    # Set anisotropy level
+    apd.ani_thres = anisotropy
+
+    # Override pixel grid directly
+    apd.pixel_params = list(grid_size)
+
+    # Build voxel centers
+    apd.assemble_pixels()
+
+    # Optional optimization of weights
+    if optimize_weights:
+        apd.find_optimal_W()
+
+    # Optional Lloyd relaxation
+    for _ in range(lloyd_iterations):
+        apd.Lloyds_algorithm(verbosity_level=0)
+
+    # Compute APD assignment
+    assignments = apd.assemble_apd()
+
+    # Move GPU tensor to CPU before NumPy conversion
+    if hasattr(assignments, "detach"):
+        assignments = assignments.detach().cpu().numpy()
+
+    # Convert to voxel grid
+    labels = np.array(assignments).reshape(grid_size)
+
+    return labels, apd

--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -1422,6 +1422,29 @@
       script_data_out: direct
       script_exe: python_script
 
+- objective: generate_volume_element
+  method: APD
+  inputs:
+    - parameter: num_grains
+    - parameter: VE_grid_size
+    - parameter: VE_size
+    - parameter: phase_label
+    - parameter: homog_label
+      default_value: SX
+    - parameter: orientations
+      default_value: null
+  outputs:
+    - parameter: volume_element
+  actions:
+    - script: <<script:pyapd/generate_VE_PyAPD.py>>
+      script_data_in: direct
+      script_data_out: direct
+      script_exe: python_script
+      environments:
+        - scope:
+            type: any
+          environment: damask_parse_env
+
 - objective: load_microstructure
   doc: Get a 2D microstructure model from a differential interference contrast microscopy image.
   method: EBSD_DIC

--- a/matflow/data/template_components/task_schemas.yaml
+++ b/matflow/data/template_components/task_schemas.yaml
@@ -1443,10 +1443,12 @@
       environments:
         - scope:
             type: any
-          environment: damask_parse_env
+          environment: pytorch_env
 
 - objective: load_microstructure
-  doc: Get a 2D microstructure model from a differential interference contrast microscopy image.
+  doc: |
+    Get a 2D microstructure model from a combination of electron backscatter diffraction 
+    (EBSD) and digital image correlation (DIC) data.
   method: EBSD_DIC
   inputs:
     - parameter: DIC

--- a/matflow/data/workflows/damask_apd.yaml
+++ b/matflow/data/workflows/damask_apd.yaml
@@ -1,0 +1,84 @@
+
+tasks:
+  - schema: generate_volume_element_APD
+    inputs:
+      VE_grid_size: [8, 8, 8]
+      VE_size: [1, 1, 1]
+      num_grains: 4
+      phase_label: Al
+
+  - schema: visualise_VE_VTK
+
+  - schema: simulate_VE_loading_damask
+    inputs:
+      load_case::uniaxial:
+        total_time: 100
+        num_increments: 200
+        direction: x
+        target_def_grad_rate: 1.0e-3
+        dump_frequency: 1
+      homogenization:
+        SX:
+          mechanical: { type: "pass" }
+          N_constituents: 1
+      damask_phases:
+        Al:
+          lattice: cF
+          mechanical:
+            output: [F, P, F_e, F_p, L_p, O]
+            elastic:
+              type: Hooke
+              C_11: 106750000000
+              C_12: 60410000000
+              C_44: 28340000000
+            plastic:
+              type: phenopowerlaw
+              N_sl: [12]
+              a_sl: 2.25
+              atol_xi: 1
+              dot_gamma_0_sl: 0.001
+              h_0_sl-sl: 75.0e+6
+              h_sl-sl: [1, 1, 1.4, 1.4, 1.4, 1.4, 1.4]
+              n_sl: 20
+              output: [xi_sl]
+              xi_0_sl: [31.0e+6]
+              xi_inf_sl: [63.0e+6]
+      damask_post_processing:
+        - name: add_stress_Cauchy
+          args: { P: P, F: F }
+          opts: { add_Mises: true }
+        - name: add_strain
+          args: { F: F, t: V, m: 0 }
+          opts: { add_Mises: true }
+        - name: add_strain
+          args: { F: F_p, t: V, m: 0 }
+          opts: { add_Mises: true }
+        - name: add_IPF_color
+          args: { l: [0, 0, 1] }
+      VE_response_data:
+        phase_data:
+          - field_name: sigma_vM
+            phase_name: Al
+            out_name: vol_avg_equivalent_stress
+            transforms: [{ mean_along_axes: 1 }]
+          - field_name: epsilon_V^0(F)_vM
+            phase_name: Al
+            out_name: vol_avg_equivalent_strain
+            transforms: [{ mean_along_axes: 1 }]
+          - field_name: epsilon_V^0(F_p)_vM
+            phase_name: Al
+            out_name: vol_avg_equivalent_plastic_strain
+            transforms: [{ mean_along_axes: 1 }]
+        field_data:
+          - field_name: phase
+          - field_name: O
+        grain_data:
+          - field_name: O
+            increments: [{ values: [0, -1] }]
+      damask_viz:
+        fields:
+          [F, F_p, P, sigma_vM, epsilon_V^0(F_p)_vM, IPFcolor_(0 0 1), phase]
+        increments:
+          - step: 20
+      calculate_yield_stress:
+        yield_point: 0.002

--- a/matflow/data/workflows/generate_VE_APD.yaml
+++ b/matflow/data/workflows/generate_VE_APD.yaml
@@ -1,0 +1,9 @@
+tasks:
+  - schema: generate_volume_element_APD
+    inputs:
+      VE_grid_size: [16, 16, 16]
+      VE_size: [1, 1, 1]
+      num_grains: 10
+      phase_label: Al
+
+  - schema: visualise_VE_VTK

--- a/matflow/environments.py
+++ b/matflow/environments.py
@@ -96,6 +96,7 @@ def env_configure_python_all(
             "defdap",
             "gmsh",
             "moose_processing",
+            "pytorch_env",
         ),
     )
 


### PR DESCRIPTION
This adds basic support for using [PyAPD](https://github.com/mbuze/PyAPD) to generate volume elements. PyAPD works with and without GPU. It does not currently work on Windows [due to pykeops](https://github.com/getkeops/keops/issues/43).

Outstanding:

- [ ] support generating periodic microstructures (for use in, for example, DAMASK).